### PR TITLE
pre2 typo, step and nvict support #5

### DIFF
--- a/common/common.py
+++ b/common/common.py
@@ -60,19 +60,30 @@ def pre_edge_with_defaults(group: Group, settings: dict = None):
         bkg_parameters = None
 
     keys = (
-        ("e0", "e0"),
-        ("pre1", "pre1"),
-        ("pre1", "pre1"),
-        ("norm1", "nor1"),
-        ("norm2", "nor2"),
-        ("nnorm", "nnorm"),
-        ("make_flat", "flatten"),
+        ("e0", "e0", None),
+        ("pre1", "pre1", None),
+        ("pre2", "pre2", None),
+        ("norm1", "nor1", None),
+        ("norm2", "nor2", None),
+        ("nnorm", "nnorm", None),
+        ("make_flat", "flatten", None),
+        ("step", "step", None),
+        # This cannot be read from file as it is not stored by Larch (0.9.71)
+        # ("nvict", "nvict", None),
     )
-    for key, parameters_key in keys:
-        extract_attribute(merged_settings, key, bkg_parameters, parameters_key)
+    for key, parameters_key, default in keys:
+        extract_attribute(
+            merged_settings, key, bkg_parameters, parameters_key, default
+        )
 
     if settings:
         for k, v in settings.items():
+            if k == "nvict":
+                print(
+                    "WARNING: `nvict` can be used for pre-edge but is not "
+                    "saved to file, so value used will not be accessible in "
+                    "future operations using this Athena .prj"
+                )
             merged_settings[k] = v
 
     print(f"Pre-edge normalization with {merged_settings}")

--- a/larch_athena/larch_athena.xml
+++ b/larch_athena/larch_athena.xml
@@ -151,6 +151,7 @@
                     <param argument="e0" type="float" label="Edge energy (eV)" optional="true" help="If set, normalization will use this as the location of the edge rather than automatically determining it."/>
                     <param argument="pre1" type="float" max="0" label="Pre-edge fit lower energy (eV)" optional="true" help="The lower end of the region used for the pre-edge fitting, relative to the edge energy (and therefore negative)."/>
                     <param argument="pre2" type="float" max="0" label="Pre-edge fit upper energy (eV)" optional="true" help="The upper end of the region used for the pre-edge fitting, relative to the edge energy (and therefore negative)."/>
+                    <param argument="nvict" type="integer" label="Energy exponent" optional="true" help="Edge fitting will be performed against μ*E**n where n is defined here. This is 0 by default."/>
                 </when>
             </conditional>
             <conditional name="xftf">


### PR DESCRIPTION
Fixes typo when loading `pre2` from file, supports `step` reading from file.

Adds option to specify `nvict`, but this does not seem to be written to file with the rest of the parameters (see discussion #5, for which these parameters were set to non-defaults in the data ).
