### PR TITLE
Bump xraylarch to 0.9.74 for all tools

### DIFF
--- a/common/common.py
+++ b/common/common.py
@@ -68,8 +68,7 @@ def pre_edge_with_defaults(group: Group, settings: dict = None):
         ("nnorm", "nnorm", None),
         ("make_flat", "flatten", None),
         ("step", "step", None),
-        # This cannot be read from file as it is not stored by Larch (0.9.71)
-        # ("nvict", "nvict", None),
+        ("nvict", "nvict", None),
     )
     for key, parameters_key, default in keys:
         extract_attribute(

--- a/larch_artemis/larch_artemis.xml
+++ b/larch_artemis/larch_artemis.xml
@@ -2,9 +2,9 @@
     <description>generate Artemis projects from XAFS data</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
-        <token name="@TOOL_VERSION@">0.9.71</token>
+        <token name="@TOOL_VERSION@">0.9.74</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">1</token>
+        <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">10.1088/1742-6596/430/1/012007</token>

--- a/larch_artemis/test-data/fit_report.txt
+++ b/larch_artemis/test-data/fit_report.txt
@@ -2,11 +2,11 @@
 \[\[Statistics\]\]
    nvarys, npts       =  6, 104
    n_independent      =  12\.205
-   chi_square         =  [\d\.]{10}
-   reduced chi_square =  [\d\.]{10}
-   r-factor           =  [\d\.]{10}
-   Akaike info crit   =  [\d\.]{10}
-   Bayesian info crit =  [\d\.]{10}
+   chi_square         =  [\d\.]{9}
+   reduced chi_square =  [\d\.]{9}
+   r-factor           =  [\d\.]{9}
+   Akaike info crit   =  [\d\.]{9}
+   Bayesian info crit =  [\d\.]{9}
 
 \[\[Data\]\]
    fit space          = 'r'
@@ -15,18 +15,18 @@
    k window, dk       = 'hanning', 1\.000
    paths used in fit  = \['feff/feff0001\.dat', 'feff/feff0002\.dat', 'feff/feff0003\.dat', 'feff/feff0004\.dat'\]
    k-weight           = 2
-   epsilon_k          = Array\(mean=5\.19133e-4, std=4\.56760e-4\)
-   epsilon_r          = [\d\.]{10}
+   epsilon_k          = Array\(mean=5\.1913e-4, std=4\.5676e-4\)
+   epsilon_r          = [\d\.]{9}
    n_independent      = 12\.205
 
 \[\[Variables\]\]
-   alpha          = [-\s][\d\.]{10} \+/- [\d\.]{10}   \(init=  1\.00000e-7\)
-   amp            = [-\s][\d\.]{10} \+/- [\d\.]{10}   \(init=  1\.00000000\)
-   enot           = [-\s][\d\.]{10} \+/- [\d\.]{10}   \(init=  1\.00000e-7\)
-   ss             = [-\s][\d\.]{10} \+/- [\d\.]{10}   \(init=  0\.00300000\)
-   ss2            = [-\s][\d\.]{10} \+/- [\d\.]{10}   \(init=  0\.00300000\)
-   ss3            = [-\s][\d\.]{10} \+/- [\d\.]{10}  = 'ss2'
-   ssfe           = [-\s][\d\.]{10} \+/- [\d\.]{10}   \(init=  0\.00300000\)
+   alpha          = [-\s][\d\.]{9} \+/- [\d\.]{9}   \(init=  1\.0000e-7\)
+   amp            = [-\s][\d\.]{9} \+/- [\d\.]{9}   \(init=  1\.0000000\)
+   enot           = [-\s][\d\.]{9} \+/- [\d\.]{9}   \(init=  1\.0000e-7\)
+   ss             = [-\s][\d\.]{9} \+/- [\d\.]{9}   \(init=  0\.0030000\)
+   ss2            = [-\s][\d\.]{9} \+/- [\d\.]{9}   \(init=  0\.0030000\)
+   ss3            = [-\s][\d\.]{9} \+/- [\d\.]{9}  = 'ss2'
+   ssfe           = [-\s][\d\.]{9} \+/- [\d\.]{9}   \(init=  0\.0030000\)
 
 \[\[Correlations\]\]    \(unreported correlations are <  0\.100\)
    \w+, \w+\s+= [\s\-]0\.\d{3}
@@ -51,51 +51,51 @@
     geometry  atom      x        y        z      ipot
               Rh       0\.0000,  0\.0000,  0\.0000  0 \(absorber\)
                C      -0\.7410,  0\.2885, -1\.7419  3
-     reff   =  [\d\.]{10}
-     degen  =  1\.00000000
-     n\*s02  = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'amp'
-     e0     = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'enot'
-     r      = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'reff \+ alpha\*reff'
-     deltar = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'alpha\*reff'
-     sigma2 = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'ss'
+     reff   =  [\d\.]{9}
+     degen  =  1\.0000000
+     n\*s02  = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'amp'
+     e0     = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'enot'
+     r      = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'reff \+ alpha\*reff'
+     deltar = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'alpha\*reff'
+     sigma2 = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'ss'
 
  = Path 'S2' = Rh K Edge
     feffdat file = feff/feff0002\.dat, from feff run 'feff'
     geometry  atom      x        y        z      ipot
               Rh       0\.0000,  0\.0000,  0\.0000  0 \(absorber\)
                C       1\.4414,  0\.4279,  1\.2965  3
-     reff   =  [\d\.]{10}
-     degen  =  1\.00000000
-     n\*s02  = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'amp'
-     e0     = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'enot'
-     r      = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'reff \+ alpha\*reff'
-     deltar = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'alpha\*reff'
-     sigma2 = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'ss2'
+     reff   =  [\d\.]{9}
+     degen  =  1\.0000000
+     n\*s02  = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'amp'
+     e0     = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'enot'
+     r      = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'reff \+ alpha\*reff'
+     deltar = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'alpha\*reff'
+     sigma2 = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'ss2'
 
  = Path 'S3' = Rh K Edge
     feffdat file = feff/feff0003\.dat, from feff run 'feff'
     geometry  atom      x        y        z      ipot
               Rh       0\.0000,  0\.0000,  0\.0000  0 \(absorber\)
                C      -1\.6586, -0\.1094,  1\.2084  3
-     reff   =  [\d\.]{10}
-     degen  =  1\.00000000
-     n\*s02  = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'amp'
-     e0     = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'enot'
-     r      = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'reff \+ alpha\*reff'
-     deltar = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'alpha\*reff'
-     sigma2 = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'ss3'
+     reff   =  [\d\.]{9}
+     degen  =  1\.0000000
+     n\*s02  = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'amp'
+     e0     = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'enot'
+     r      = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'reff \+ alpha\*reff'
+     deltar = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'alpha\*reff'
+     sigma2 = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'ss3'
 
  = Path 'Fe' = Rh K Edge
     feffdat file = feff/feff0004\.dat, from feff run 'feff'
     geometry  atom      x        y        z      ipot
               Rh       0\.0000,  0\.0000,  0\.0000  0 \(absorber\)
                C       0\.6043, -2\.0001,  0\.0975  3
-     reff   =  [\d\.]{10}
-     degen  =  1\.00000000
-     n\*s02  = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'amp'
-     e0     = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'enot'
-     r      = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'reff \+ alpha\*reff'
-     deltar = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'alpha\*reff'
-     sigma2 = [-\s][\d\.]{10} \+/- [\d\.]{10}  := 'ssfe'
+     reff   =  [\d\.]{9}
+     degen  =  1\.0000000
+     n\*s02  = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'amp'
+     e0     = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'enot'
+     r      = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'reff \+ alpha\*reff'
+     deltar = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'alpha\*reff'
+     sigma2 = [-\s][\d\.]{9} \+/- [\d\.]{9}  := 'ssfe'
 
 =======================================================

--- a/larch_athena/larch_athena.xml
+++ b/larch_athena/larch_athena.xml
@@ -2,9 +2,9 @@
     <description>generate Athena projects from XAFS data</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
-        <token name="@TOOL_VERSION@">0.9.71</token>
+        <token name="@TOOL_VERSION@">0.9.74</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">1</token>
+        <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">10.1088/1742-6596/430/1/012007</token>
@@ -402,7 +402,7 @@
             <param name="format" value="athena"/>
             <param name="extract_group" value="multiple"/>
             <param name="group_name" value="merge"/>
-            <param name="group_name" value="d__Ref_PtSn_OC_MERGE_CALIBRATE"/>
+            <param name="group_name" value="d_Ref_PtSn_OC_MERGE_CALIBRATE"/>
             <param name="dat_file" value="multiple.prj"/>
             <output_collection name="athena_project_file_collection" type="list" count="2"/>
         </test>

--- a/larch_feff/larch_feff.xml
+++ b/larch_feff/larch_feff.xml
@@ -2,7 +2,7 @@
     <description>generate FEFF paths from XAFS data</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
-        <token name="@TOOL_VERSION@">0.9.71</token>
+        <token name="@TOOL_VERSION@">0.9.74</token>
         <!-- version of this tool wrapper (integer) -->
         <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->

--- a/larch_lcf/larch_lcf.xml
+++ b/larch_lcf/larch_lcf.xml
@@ -2,9 +2,9 @@
     <description>perform linear combination fit on XAS data</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
-        <token name="@TOOL_VERSION@">0.9.71</token>
+        <token name="@TOOL_VERSION@">0.9.74</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">1</token>
+        <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">10.1088/1742-6596/430/1/012007</token>

--- a/larch_plot/larch_plot.xml
+++ b/larch_plot/larch_plot.xml
@@ -2,9 +2,9 @@
     <description>plot Athena projects</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
-        <token name="@TOOL_VERSION@">0.9.71</token>
+        <token name="@TOOL_VERSION@">0.9.74</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">1</token>
+        <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">10.1088/1742-6596/430/1/012007</token>

--- a/larch_select_paths/larch_select_paths.xml
+++ b/larch_select_paths/larch_select_paths.xml
@@ -2,9 +2,9 @@
     <description>select FEFF paths for XAFS data</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
-        <token name="@TOOL_VERSION@">0.9.71</token>
+        <token name="@TOOL_VERSION@">0.9.74</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">1</token>
+        <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">10.1088/1742-6596/430/1/012007</token>


### PR DESCRIPTION
Contains fix for `nvict`
Required some changes to tests:
- group ids change for Athena
- Reduced precision in Artemis report values