### PR TITLE
Use provided key early when selecting group in athena

### DIFF
--- a/common/common.py
+++ b/common/common.py
@@ -11,8 +11,6 @@ def get_group(athena_group: AthenaGroup, key: str = None) -> Group:
     group_keys = list(athena_group.keys())
     if key is None:
         key = group_keys[0]
-    else:
-        key = key.replace("-", "_")
 
     try:
         return extract_athenagroup(athena_group.groups[key])
@@ -20,7 +18,7 @@ def get_group(athena_group: AthenaGroup, key: str = None) -> Group:
         raise KeyError(f"{key} not in {group_keys}") from e
 
 
-def read_all_groups(dat_file: str, key: str = None) -> "dict[str, Group]":
+def read_all_groups(dat_file: str) -> "dict[str, Group]":
     # Cannot rely on do_ABC as _larch is None
     athena_group = read_athena(
         dat_file,
@@ -40,14 +38,20 @@ def read_all_groups(dat_file: str, key: str = None) -> "dict[str, Group]":
 
 
 def read_group(dat_file: str, key: str = None):
+    if key:
+        match_ = key.replace(" ", "_").replace("-", "_").replace(".", "_")
+    else:
+        match_ = None
+
     # Cannot rely on do_ABC as _larch is None
     athena_group = read_athena(
         dat_file,
+        match=match_,
         do_preedge=False,
         do_bkg=False,
         do_fft=False,
     )
-    group = get_group(athena_group, key)
+    group = get_group(athena_group, match_)
     pre_edge_with_defaults(group=group)
     xftf_with_defaults(group=group)
     return group

--- a/larch_athena/larch_athena.xml
+++ b/larch_athena/larch_athena.xml
@@ -4,7 +4,7 @@
         <!-- version of underlying tool (PEP 440) -->
         <token name="@TOOL_VERSION@">0.9.75</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">2</token>
+        <token name="@WRAPPER_VERSION@">3</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">10.1088/1742-6596/430/1/012007</token>


### PR DESCRIPTION
Current method of selection loads all groups with Larch, then applies any selection criteria. This means if one of the groups fails to load, then the whole read operation fails. This can occur when the group does not actually represent a spectra with an x value of energy. This can be avoided by using the `match` parameter, which will `continue` inside Larch's `for` loop and so avoids any problem groups.

Functionally, this should result in unchanged functionality, except to avoid edge case bugs.