### PR TITLE
Proper handling of alternate kw/kweight names in .prj

### DIFF
--- a/common/common.py
+++ b/common/common.py
@@ -75,22 +75,22 @@ def pre_edge_with_defaults(
             bkg_parameters = None
 
     keys = (
-        ("e0", "e0", None),
-        ("pre1", "pre1", None),
-        ("pre2", "pre2", None),
-        ("norm1", "nor1", None),
-        ("norm2", "nor2", None),
-        ("nnorm", "nnorm", None),
-        ("make_flat", "flatten", None),
-        ("step", "step", None),
-        ("nvict", "nvict", None),
+        ("e0", ("e0"), None),
+        ("pre1", ("pre1"), None),
+        ("pre2", ("pre2"), None),
+        ("norm1", ("nor1"), None),
+        ("norm2", ("nor2"), None),
+        ("nnorm", ("nnorm"), None),
+        ("make_flat", ("flatten"), None),
+        ("step", ("step"), None),
+        ("nvict", ("nvict"), None),
     )
-    for key, parameters_key, default in keys:
+    for key, parameter_keys, default in keys:
         extract_attribute(
             merged_settings=merged_settings,
             key=key,
             parameters_group=bkg_parameters,
-            parameters_key=parameters_key,
+            parameter_keys=parameter_keys,
             default=default,
         )
 
@@ -125,19 +125,18 @@ def xftf_with_defaults(group: Group, settings: dict = None):
         fft_parameters = None
 
     keys = (
-        ("kmin", "kmin", 0),
-        ("kmax", "kmax", 20),
-        ("dk", "dk", 1),
-        ("kweight", "kw", 2),
-        ("kweight", "kweight", 2),
-        ("window", "kwindow", "kaiser"),
+        ("kmin", ("kmin",), 0),
+        ("kmax", ("kmax",), 20),
+        ("dk", ("dk",), 1),
+        ("kweight", ("kw", "kweight"), 2),
+        ("window", ("kwindow",), "kaiser"),
     )
-    for key, parameters_key, default in keys:
+    for key, parameter_keys, default in keys:
         extract_attribute(
             merged_settings=merged_settings,
             key=key,
             parameters_group=fft_parameters,
-            parameters_key=parameters_key,
+            parameter_keys=parameter_keys,
             default=default,
         )
 
@@ -156,15 +155,26 @@ def extract_attribute(
     merged_settings: dict,
     key: str,
     parameters_group: Group,
-    parameters_key: str,
+    parameter_keys: "tuple[str]",
     default: "str|int" = None,
 ):
     if parameters_group is not None:
-        try:
-            merged_settings[key] = getattr(parameters_group, parameters_key)
+        values = []
+        for parameter_key in parameter_keys:
+            try:
+                values.append(getattr(parameters_group, parameter_key))
+            except AttributeError:
+                pass
+
+        if len(values) > 1:
+            print(
+                f"WARNING: values {values} for for keys {parameter_keys}, "
+                "using first entry"
+            )
+        
+        if len(values) > 0:
+            merged_settings[key] = values[0]
             return
-        except AttributeError:
-            pass
 
     if default is not None:
         merged_settings[key] = default

--- a/common/common.py
+++ b/common/common.py
@@ -171,7 +171,7 @@ def extract_attribute(
                 f"WARNING: values {values} for for keys {parameter_keys}, "
                 "using first entry"
             )
-        
+
         if len(values) > 0:
             merged_settings[key] = values[0]
             return

--- a/larch_artemis/larch_artemis.xml
+++ b/larch_artemis/larch_artemis.xml
@@ -4,7 +4,7 @@
         <!-- version of underlying tool (PEP 440) -->
         <token name="@TOOL_VERSION@">0.9.80</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">1</token>
+        <token name="@WRAPPER_VERSION@">2</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">10.1088/1742-6596/430/1/012007</token>

--- a/larch_artemis/test-data/fit_report.txt
+++ b/larch_artemis/test-data/fit_report.txt
@@ -1,6 +1,6 @@
 =================== FEFFIT RESULTS ====================
 \[\[Statistics\]\]
-  n_function_calls     = 4\d\d
+  n_function_calls     = \d{3}
   n_variables          = 6
   n_data_points        = 104
   n_independent        = 12\.2045080
@@ -37,14 +37,14 @@
 
 
 \[\[Dataset\]\]
-  unique_id            = 'dm7xe57x'
+  unique_id            = '\w{8}'
   fit space            = 'r'
   r-range              = 1\.400, 3\.000
   k-range              = 3\.000, 14\.000
   k window, dk         = 'hanning', 1\.000
   paths used in fit    = \['feff/feff0001\.dat', 'feff/feff0002\.dat', 'feff/feff0003\.dat', 'feff/feff0004\.dat'\]
   k-weight             = 2
-  epsilon_k            = Array\(mean=5\.1913e-4, std=4\.5676e-4\)
+  epsilon_k            = Array\(mean=5\.\d{4}e-4, std=4\.5\d{3}e-4\)
   epsilon_r            = [\d\.]{9}
   n_independent        = 12\.205
 

--- a/larch_artemis/test-data/fit_report_simultaneous.txt
+++ b/larch_artemis/test-data/fit_report_simultaneous.txt
@@ -1,6 +1,6 @@
 =================== FEFFIT RESULTS ====================
 \[\[Statistics\]\]
-  n_function_calls     = 4\d\d
+  n_function_calls     = \d{3}
   n_variables          = 6
   n_data_points        = 208
   n_independent        = 24\.4090160
@@ -37,14 +37,14 @@
 
 
 \[\[Dataset 1 of 2\]\]
-  unique_id            = 'dm7xe57x'
+  unique_id            = '\w{8}'
   fit space            = 'r'
   r-range              = 1\.400, 3\.000
   k-range              = 3\.000, 14\.000
   k window, dk         = 'hanning', 1\.000
   paths used in fit    = \['feff/feff0001\.dat', 'feff/feff0002\.dat', 'feff/feff0003\.dat', 'feff/feff0004\.dat'\]
   k-weight             = 2
-  epsilon_k            = Array\(mean=5\.1913e-4, std=4\.5676e-4\)
+  epsilon_k            = Array\(mean=5\.\d{4}e-4, std=4\.5\d{3}e-4\)
   epsilon_r            = [\d\.]{9}
   n_independent        = 12\.205
 
@@ -109,7 +109,7 @@
   k window, dk         = 'hanning', 1\.000
   paths used in fit    = \['feff/feff0001\.dat', 'feff/feff0002\.dat', 'feff/feff0003\.dat', 'feff/feff0004\.dat'\]
   k-weight             = 2
-  epsilon_k            = Array\(mean=5\.1913e-4, std=4\.5676e-4\)
+  epsilon_k            = Array\(mean=5\.\d{4}e-4, std=4\.5\d{3}e-4\)
   epsilon_r            = [\d\.]{9}
   n_independent        = 12\.205
 

--- a/larch_athena/larch_athena.xml
+++ b/larch_athena/larch_athena.xml
@@ -4,7 +4,7 @@
         <!-- version of underlying tool (PEP 440) -->
         <token name="@TOOL_VERSION@">0.9.80</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">0</token>
+        <token name="@WRAPPER_VERSION@">1</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">10.1088/1742-6596/430/1/012007</token>

--- a/larch_lcf/larch_lcf.xml
+++ b/larch_lcf/larch_lcf.xml
@@ -82,11 +82,11 @@
             <param name="x_limit_max" value="29230"/>
             <output name="plot">
                 <assert_contents>
-                    <has_size value="59500" delta="100"/>
+                    <has_size value="61000" delta="1000"/>
                 </assert_contents>
             </output>
             <assert_stdout>
-                <has_text text="Goodness of fit (rfactor): 0.532130%"/>
+                <has_text text="Goodness of fit (rfactor): 0.658596%"/>
             </assert_stdout>
         </test>
         <!-- 2: series -->
@@ -101,7 +101,7 @@
             <param name="x_limit_max" value="29230"/>
             <output_collection name="plot_collection" type="list" count="1"/>
             <assert_stdout>
-                <has_text text="Goodness of fit (rfactor): 0.532130%"/>
+                <has_text text="Goodness of fit (rfactor): 0.658596%"/>
             </assert_stdout>
         </test>
         <!-- 3: zipped -->
@@ -116,7 +116,7 @@
             <param name="x_limit_max" value="29230"/>
             <output_collection name="plot_collection" type="list" count="2"/>
             <assert_stdout>
-                <has_text text="Goodness of fit (rfactor): 0.532130%"/>
+                <has_text text="Goodness of fit (rfactor): 0.658596%"/>
             </assert_stdout>
         </test>
     </tests>

--- a/larch_lcf/larch_lcf.xml
+++ b/larch_lcf/larch_lcf.xml
@@ -4,7 +4,7 @@
         <!-- version of underlying tool (PEP 440) -->
         <token name="@TOOL_VERSION@">0.9.80</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">0</token>
+        <token name="@WRAPPER_VERSION@">1</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">10.1088/1742-6596/430/1/012007</token>

--- a/larch_plot/larch_plot.xml
+++ b/larch_plot/larch_plot.xml
@@ -4,7 +4,7 @@
         <!-- version of underlying tool (PEP 440) -->
         <token name="@TOOL_VERSION@">0.9.80</token>
         <!-- version of this tool wrapper (integer) -->
-        <token name="@WRAPPER_VERSION@">0</token>
+        <token name="@WRAPPER_VERSION@">1</token>
         <!-- citation should be updated with every underlying tool version -->
         <!-- typical fields to update are version, month, year, and doi -->
         <token name="@TOOL_CITATION@">10.1088/1742-6596/430/1/012007</token>


### PR DESCRIPTION
Support multiple parameter names without overwriting one another, and explicitly warning if two possible values are found.

Bumping the version of all tools which indirectly use this functionality (those which load Athena projects).