### PR TITLE
Fix handling of special degen behaviour #86

### DIFF
--- a/larch_select_paths/larch_select_paths.py
+++ b/larch_select_paths/larch_select_paths.py
@@ -186,7 +186,7 @@ class GDSWriter:
         else:
             auto_name = self.default_properties[property_name]["name"]
             value = self.default_properties[property_name]["value"]
-            if auto_name == "degen_variable":
+            if auto_name == "degen_variable" and value == None:
                 value = feff_degen_value
 
             if directory_label:

--- a/larch_select_paths/larch_select_paths.py
+++ b/larch_select_paths/larch_select_paths.py
@@ -186,7 +186,7 @@ class GDSWriter:
         else:
             auto_name = self.default_properties[property_name]["name"]
             value = self.default_properties[property_name]["value"]
-            if auto_name == "degen_variable" and value == None:
+            if auto_name == "degen_variable" and value is None:
                 value = feff_degen_value
 
             if directory_label:

--- a/larch_select_paths/larch_select_paths.py
+++ b/larch_select_paths/larch_select_paths.py
@@ -58,7 +58,7 @@ class ManualSelector:
 class GDSWriter:
     def __init__(self, default_variables: "dict[str, dict]"):
         self.default_properties = {
-            "degen": {"name": "degen"},
+            "degen": {"name": "degen_variable"},
             "s02": {"name": "s02"},
             "e0": {"name": "e0"},
             "deltar": {"name": "alpha"},
@@ -71,16 +71,34 @@ class GDSWriter:
         self.names = set()
 
         for property in self.default_properties:
-            name = self.default_properties[property]["name"]
-            value = default_variables[property]["value"]
-            vary = default_variables[property]["vary"]
-            is_common = default_variables[property]["is_common"]
+            default_variable = default_variables[property]
+            vary = default_variable["vary"]
+            if "degeneracy_origin" in default_variable:
+                degeneracy_dict = default_variable["degeneracy_origin"]
+                degeneracy_origin = degeneracy_dict["degeneracy_origin"]
+                if degeneracy_origin == "feff":
+                    value = None
+                    if default_variable["vary"]:
+                        is_common = False
+                    else:
+                        self.default_properties["degen"]["name"] = "degen"
+                        is_common = True
+
+                elif degeneracy_origin == "manual":
+                    value = degeneracy_dict["value"]
+                    is_common = degeneracy_dict["is_common"]
+
+            else:
+                value = default_variable["value"]
+                vary = default_variable["vary"]
+                is_common = default_variable["is_common"]
 
             self.default_properties[property]["value"] = value
             self.default_properties[property]["vary"] = vary
             self.default_properties[property]["is_common"] = is_common
 
             if is_common:
+                name = self.default_properties[property]["name"]
                 self.append_gds(name=name, value=value, vary=vary)
 
     def append_gds(
@@ -127,6 +145,7 @@ class GDSWriter:
     def parse_gds(
         self,
         property_name: str,
+        feff_degen_value: float,
         variable_name: str = None,
         path_variable: dict = None,
         directory_label: str = None,
@@ -138,6 +157,8 @@ class GDSWriter:
         Args:
             property_name (str): The property to which the variable
                 corresponds. Should be a key in `self.default_properties`.
+            feff_degen_value (float):
+                The degeneracy determined by FEFF for this path.
             variable_name (str, optional): Custom name for this variable.
                 Defaults to None.
             path_variable (dict, optional): Dictionary defining the GDS
@@ -164,6 +185,10 @@ class GDSWriter:
             return self.default_properties[property_name]["name"]
         else:
             auto_name = self.default_properties[property_name]["name"]
+            value = self.default_properties[property_name]["value"]
+            if auto_name == "degen_variable":
+                value = feff_degen_value
+
             if directory_label:
                 auto_name += f"_{directory_label}"
             if path_label:
@@ -171,7 +196,7 @@ class GDSWriter:
 
             self.append_gds(
                 name=auto_name,
-                value=self.default_properties[property_name]["value"],
+                value=value,
                 vary=self.default_properties[property_name]["vary"],
             )
             return auto_name
@@ -271,9 +296,14 @@ class PathsWriter:
                     )
                     if selected:
                         filename = row[0].strip()
+                        feff_degen_value = float(row[3].strip())
                         path_label = row[-2].strip()
                         row_id = self.parse_row(
-                            directory_label, filename, path_label, path_value
+                            directory_label,
+                            filename,
+                            path_label,
+                            path_value,
+                            feff_degen_value,
                         )
                         row_ids.append(row_id)
 
@@ -285,6 +315,7 @@ class PathsWriter:
         filename: str,
         path_label: str,
         path_value: "None|dict",
+        feff_degen_value: float,
     ) -> int:
         """Parse row for GDS and path information.
 
@@ -295,6 +326,8 @@ class PathsWriter:
             path_label (str): Label for the FEFF path, extracted from row.
             path_value (None|dict): The values associated with the selected
                 FEFF path. May be None in which case defaults are used.
+            feff_degen_value (float):
+                The degeneracy determined by FEFF for this path.
 
         Returns:
             int: The id of the added row.
@@ -304,6 +337,7 @@ class PathsWriter:
             for property in self.gds_writer.default_properties:
                 variables[property] = self.gds_writer.parse_gds(
                     property_name=property,
+                    feff_degen_value=feff_degen_value,
                     variable_name=path_value[property]["name"],
                     path_variable=path_value[property],
                     directory_label=directory_label,
@@ -313,6 +347,7 @@ class PathsWriter:
             for property in self.gds_writer.default_properties:
                 variables[property] = self.gds_writer.parse_gds(
                     property_name=property,
+                    feff_degen_value=feff_degen_value,
                     directory_label=directory_label,
                     path_label=path_label,
                 )

--- a/larch_select_paths/larch_select_paths.xml
+++ b/larch_select_paths/larch_select_paths.xml
@@ -271,7 +271,9 @@
         <test expect_num_outputs="2">
             <section name="variables">
                 <section name="degen">
-                    <param name="degeneracy_origin" value="feff"/>
+                    <conditional name="degeneracy_origin">
+                        <param name="degeneracy_origin" value="feff"/>
+                    </conditional>
                     <param name="vary" value="true"/>
                 </section>
             </section>
@@ -285,8 +287,10 @@
         <test expect_num_outputs="2">
             <section name="variables">
                 <section name="degen">
-                    <param name="degeneracy_origin" value="manual"/>
-                    <param name="is_common" value="true"/>
+                    <conditional name="degeneracy_origin">
+                        <param name="degeneracy_origin" value="manual"/>
+                        <param name="is_common" value="true"/>
+                    </conditional>
                     <param name="vary" value="true"/>
                 </section>
             </section>
@@ -300,8 +304,10 @@
         <test expect_num_outputs="2">
             <section name="variables">
                 <section name="degen">
-                    <param name="degeneracy_origin" value="manual"/>
-                    <param name="is_common" value="false"/>
+                    <conditional name="degeneracy_origin">
+                        <param name="degeneracy_origin" value="manual"/>
+                        <param name="is_common" value="false"/>
+                    </conditional>
                     <param name="vary" value="true"/>
                 </section>
             </section>
@@ -309,7 +315,7 @@
             <param name="paths_file" value="[CSV_summary_of_1564889.cif].csv"/>
             <param name="selection" value="manual"/>
             <output name="gds_csv" file="gds_degen_manual_unique.csv"/>
-            <output name="sp_csv" file="sp_select_all_degen_unique.csv"/>
+            <output name="sp_csv" file="sp_select_all_false_degen_unique.csv"/>
         </test>
         <!-- 10: Test merging defaults -->
         <test expect_num_outputs="3">

--- a/larch_select_paths/larch_select_paths.xml
+++ b/larch_select_paths/larch_select_paths.xml
@@ -2,7 +2,7 @@
     <description>select FEFF paths for XAFS data</description>
     <macros>
         <!-- version of underlying tool (PEP 440) -->
-        <token name="@TOOL_VERSION@">0.9.80</token>
+        <token name="@TOOL_VERSION@">0.9.81</token>
         <!-- version of this tool wrapper (integer) -->
         <token name="@WRAPPER_VERSION@">0</token>
         <!-- citation should be updated with every underlying tool version -->
@@ -46,9 +46,18 @@
     <inputs>
         <section name="variables" expanded="false" title="GDS variable defaults" help="Define default values for variables in the EXAFS equation to use for the paths selected below.">
             <section name="degen" expanded="false" title="N: path degeneracy">
-                <param name="is_common" type="boolean" checked="true" label="Use path default" help="If set, a single variable 'degen' will be used for all paths. Otherwise, each path has a distinct variable."/>
-                <param name="value" type="float" optional="true" min="0.0" label="Value" help="The initial value for 'degen'. This will depend on the structure and path in question. If unset, then the path default will be used."/>
-                <expand macro="vary"/>
+                <conditional name="degeneracy_origin">
+                    <param name="degeneracy_origin" type="select" display="radio" label="Degeneracy origin" help="Whether to source (initial or unvarying) degeneracy from the FEFF calculation or a manual definition.">
+                        <option value="feff" selected="true">FEFF</option>
+                        <option value="manual">Manual</option>
+                    </param>
+                    <when value="feff"/>
+                    <when value="manual">
+                        <param name="is_common" type="boolean" checked="true" label="Common to all paths" help="If set, a single variable 'degeneracy' will be used for all paths. Otherwise, each path has a distinct variable."/>
+                        <param name="value" type="float" value="1" min="0.0" label="Value" help="The initial value for 'degeneracy' for all paths (unless overwritten in individual path selection)."/>
+                    </when>
+                </conditional>
+                <param name="vary" type="boolean" checked="false" label="Vary" help="If True, the initial 'Guess' will be optimised in the fitting. If False, the value will be 'Set' instead and not optimised."/>
             </section>
             <section name="s02" expanded="false" title="S02: passive electron reduction factor">
                 <param name="is_common" type="boolean" checked="true" label="Common to all paths" help="If set, a single variable 's02' will be used for all paths. Otherwise, each path has a distinct variable."/>
@@ -87,7 +96,7 @@
                         <param name="id" type="integer" value="1" min="1" label="Path ID" help="Numerical id of a path to select, this appears at the end of the label and filename in the path summary CSV."/>
                         <section name="degen" expanded="false" title="N: path degeneracy">
                             <expand macro="name"/>
-                            <param name="value" type="float" optional="true" min="0.0" label="Value" help="The initial value for 'degen'. This will depend on the structure and path in question."/>
+                            <param name="value" type="float" value="1" min="0.0" label="Value" help="The initial value for 'degeneracy'. This will overwrite any use of the FEFF generated degeneracy."/>
                             <expand macro="expr"/>
                             <expand macro="vary"/>
                         </section>
@@ -183,14 +192,14 @@
         </collection>
     </outputs>
     <tests>
-        <!-- Test defaults for CSV with select_all -->
+        <!--  1: Test defaults for CSV with select_all -->
         <test expect_num_outputs="2">
             <param name="paths_zip" value="FEFF_paths.zip"/>
             <param name="paths_file" value="[CSV_summary_of_1564889.cif].csv"/>
             <output name="gds_csv" file="gds_default.csv"/>
             <output name="sp_csv" file="sp_default.csv"/>
         </test>
-        <!-- Test defaults for CSV with some selected rows -->
+        <!--  2: Test defaults for CSV with some selected rows -->
         <test expect_num_outputs="2">
             <param name="paths_zip" value="FEFF_paths.zip"/>
             <param name="paths_file" value="[CSV_summary_of_1564889.cif].csv"/>
@@ -198,7 +207,7 @@
             <output name="gds_csv" file="gds_default.csv"/>
             <output name="sp_csv" file="sp_select_all_false.csv"/>
         </test>
-        <!-- Test selected paths without custom GDS -->
+        <!--  3: Test selected paths without custom GDS -->
         <test expect_num_outputs="2">
             <param name="paths_zip" value="FEFF_paths.zip"/>
             <param name="paths_file" value="[CSV_summary_of_1564889.cif].csv"/>
@@ -207,7 +216,7 @@
             <output name="gds_csv" file="gds_default.csv"/>
             <output name="sp_csv" file="sp_include_path_3.csv"/>
         </test>
-        <!-- Test selected paths with custom name but no GDS entry -->
+        <!--  4: Test selected paths with custom name but no GDS entry -->
         <test expect_num_outputs="2">
             <param name="paths_zip" value="FEFF_paths.zip"/>
             <param name="paths_file" value="[CSV_summary_of_1564889.cif].csv"/>
@@ -219,7 +228,7 @@
             <output name="gds_csv" file="gds_include_path_3_custom_name.csv"/>
             <output name="sp_csv" file="sp_include_path_3_custom_name.csv"/>
         </test>
-        <!-- Test selected paths with custom GDS -->
+        <!--  5: Test selected paths with custom GDS -->
         <test expect_num_outputs="2">
             <param name="paths_zip" value="FEFF_paths.zip"/>
             <param name="paths_file" value="[CSV_summary_of_1564889.cif].csv"/>
@@ -236,7 +245,7 @@
             <output name="gds_csv" file="gds_include_path_3_custom_name_value.csv"/>
             <output name="sp_csv" file="sp_include_path_3_custom_name.csv"/>
         </test>
-        <!-- Test changing default GDS values -->
+        <!--  6: Test changing default GDS values -->
         <test expect_num_outputs="2">
             <section name="variables">
                 <section name="s02">
@@ -258,7 +267,51 @@
             <output name="gds_csv" file="gds_altered_defaults.csv"/>
             <output name="sp_csv" file="sp_select_all_false.csv"/>
         </test>
-        <!-- Test merging defaults -->
+        <!--  7: Initialise with FEFF degen, allow to vary -->
+        <test expect_num_outputs="2">
+            <section name="variables">
+                <section name="degen">
+                    <param name="degeneracy_origin" value="feff"/>
+                    <param name="vary" value="true"/>
+                </section>
+            </section>
+            <param name="paths_zip" value="FEFF_paths.zip"/>
+            <param name="paths_file" value="[CSV_summary_of_1564889.cif].csv"/>
+            <param name="selection" value="manual"/>
+            <output name="gds_csv" file="gds_degen_feff_vary.csv"/>
+            <output name="sp_csv" file="sp_select_all_false_degen_unique.csv"/>
+        </test>
+        <!--  8: Manual degen, common to all paths -->
+        <test expect_num_outputs="2">
+            <section name="variables">
+                <section name="degen">
+                    <param name="degeneracy_origin" value="manual"/>
+                    <param name="is_common" value="true"/>
+                    <param name="vary" value="true"/>
+                </section>
+            </section>
+            <param name="paths_zip" value="FEFF_paths.zip"/>
+            <param name="paths_file" value="[CSV_summary_of_1564889.cif].csv"/>
+            <param name="selection" value="manual"/>
+            <output name="gds_csv" file="gds_degen_manual_common.csv"/>
+            <output name="sp_csv" file="sp_select_all_false_degen_manual_common.csv"/>
+        </test>
+        <!--  9: Manual degen, unique to paths -->
+        <test expect_num_outputs="2">
+            <section name="variables">
+                <section name="degen">
+                    <param name="degeneracy_origin" value="manual"/>
+                    <param name="is_common" value="false"/>
+                    <param name="vary" value="true"/>
+                </section>
+            </section>
+            <param name="paths_zip" value="FEFF_paths.zip"/>
+            <param name="paths_file" value="[CSV_summary_of_1564889.cif].csv"/>
+            <param name="selection" value="manual"/>
+            <output name="gds_csv" file="gds_degen_manual_unique.csv"/>
+            <output name="sp_csv" file="sp_select_all_degen_unique.csv"/>
+        </test>
+        <!-- 10: Test merging defaults -->
         <test expect_num_outputs="3">
             <repeat name="feff_outputs">
                 <param name="paths_zip" value="FEFF_paths.zip"/>
@@ -276,7 +329,7 @@
             <output name="gds_csv" file="gds_default.csv"/>
             <output name="sp_csv" file="sp_merge_default.csv"/>
         </test>
-        <!-- Test merging custom arguments -->
+        <!-- 11: Test merging custom arguments -->
         <test expect_num_outputs="3">
             <repeat name="feff_outputs">
                 <param name="label" value="primary"/>
@@ -314,7 +367,7 @@
             <output name="gds_csv" file="gds_merge_custom.csv"/>
             <output name="sp_csv" file="sp_merge_custom.csv"/>
         </test>
-        <!-- Test for criteria based selection -->
+        <!-- 12: Test for criteria based selection -->
         <test expect_num_outputs="2">
             <repeat name="feff_outputs">
                 <param name="paths_zip" value="FEFF_paths.zip"/>
@@ -328,7 +381,7 @@
             <output name="gds_csv" file="gds_default.csv"/>
             <output name="sp_csv" file="sp_criteria.csv"/>
         </test>
-        <!-- Test for combinations based selection -->
+        <!-- 13: Test for combinations based selection -->
         <test expect_num_outputs="3">
             <!-- Should result in 4 + 6 + 4 + 1 = 15 combinations -->
             <repeat name="feff_outputs">

--- a/larch_select_paths/test-data/gds_altered_defaults.csv
+++ b/larch_select_paths/test-data/gds_altered_defaults.csv
@@ -1,5 +1,5 @@
   id,                     name, value, expr, vary
-   1,                    degen,      ,     , True
+   1,                    degen,      ,     , False
    2,                      s02,   0.1,     , False
    3,                       e0,   0.1,     , True
    4,                    alpha,  10.0,     , False

--- a/larch_select_paths/test-data/gds_default.csv
+++ b/larch_select_paths/test-data/gds_default.csv
@@ -1,5 +1,5 @@
   id,                     name, value, expr, vary
-   1,                    degen,      ,     , True
+   1,                    degen,      ,     , False
    2,                      s02,   1.0,     , True
    3,                       e0,   0.0,     , True
    4,                    alpha,   0.0,     , True

--- a/larch_select_paths/test-data/gds_degen_feff_vary.csv
+++ b/larch_select_paths/test-data/gds_degen_feff_vary.csv
@@ -1,0 +1,7 @@
+  id,                     name, value, expr, vary
+   1,      degen_variable_sfe1,   2.0,     , True
+   2,      degen_variable_sfe2,   4.0,     , True
+   3,                      s02,   1.0,     , True
+   4,                       e0,   0.0,     , True
+   5,                    alpha,   0.0,     , True
+   6,                   sigma2, 0.003,     , True

--- a/larch_select_paths/test-data/gds_degen_feff_vary.csv
+++ b/larch_select_paths/test-data/gds_degen_feff_vary.csv
@@ -1,7 +1,7 @@
   id,                     name, value, expr, vary
-   1,      degen_variable_sfe1,   2.0,     , True
-   2,      degen_variable_sfe2,   4.0,     , True
-   3,                      s02,   1.0,     , True
-   4,                       e0,   0.0,     , True
-   5,                    alpha,   0.0,     , True
-   6,                   sigma2, 0.003,     , True
+   1,                      s02,   1.0,     , True
+   2,                       e0,   0.0,     , True
+   3,                    alpha,   0.0,     , True
+   4,                   sigma2, 0.003,     , True
+   5,      degen_variable_sfe1,   2.0,     , True
+   6,      degen_variable_sfe2,   4.0,     , True

--- a/larch_select_paths/test-data/gds_degen_manual_common.csv
+++ b/larch_select_paths/test-data/gds_degen_manual_common.csv
@@ -1,8 +1,6 @@
   id,                     name, value, expr, vary
-   1,                    degen,      ,     , False
+   1,           degen_variable,   1.0,     , True
    2,                      s02,   1.0,     , True
    3,                       e0,   0.0,     , True
    4,                    alpha,   0.0,     , True
    5,                   sigma2, 0.003,     , True
-   6,            custom_name_1, 0.003,     , True
-   7,            custom_name_2, 0.003,     , True

--- a/larch_select_paths/test-data/gds_degen_manual_unique.csv
+++ b/larch_select_paths/test-data/gds_degen_manual_unique.csv
@@ -1,7 +1,7 @@
   id,                     name, value, expr, vary
-   1,      degen_variable_sfe1,   1.0,     , True
-   2,      degen_variable_sfe2,   1.0,     , True
-   3,                      s02,   1.0,     , True
-   4,                       e0,   0.0,     , True
-   5,                    alpha,   0.0,     , True
-   6,                   sigma2, 0.003,     , True
+   1,                      s02,   1.0,     , True
+   2,                       e0,   0.0,     , True
+   3,                    alpha,   0.0,     , True
+   4,                   sigma2, 0.003,     , True
+   5,      degen_variable_sfe1,   1.0,     , True
+   6,      degen_variable_sfe2,   1.0,     , True

--- a/larch_select_paths/test-data/gds_degen_manual_unique.csv
+++ b/larch_select_paths/test-data/gds_degen_manual_unique.csv
@@ -1,0 +1,7 @@
+  id,                     name, value, expr, vary
+   1,      degen_variable_sfe1,   1.0,     , True
+   2,      degen_variable_sfe2,   1.0,     , True
+   3,                      s02,   1.0,     , True
+   4,                       e0,   0.0,     , True
+   5,                    alpha,   0.0,     , True
+   6,                   sigma2, 0.003,     , True

--- a/larch_select_paths/test-data/gds_include_path_3_custom_name.csv
+++ b/larch_select_paths/test-data/gds_include_path_3_custom_name.csv
@@ -1,5 +1,5 @@
   id,                     name, value, expr, vary
-   1,                    degen,      ,     , True
+   1,                    degen,      ,     , False
    2,                      s02,   1.0,     , True
    3,                       e0,   0.0,     , True
    4,                    alpha,   0.0,     , True

--- a/larch_select_paths/test-data/gds_include_path_3_custom_name_value.csv
+++ b/larch_select_paths/test-data/gds_include_path_3_custom_name_value.csv
@@ -1,5 +1,5 @@
   id,                     name, value, expr, vary
-   1,                    degen,      ,     , True
+   1,                    degen,      ,     , False
    2,                      s02,   1.0,     , True
    3,                       e0,   0.0,     , True
    4,                    alpha,   0.0,     , True

--- a/larch_select_paths/test-data/sp_select_all_false_degen_manual_common.csv
+++ b/larch_select_paths/test-data/sp_select_all_false_degen_manual_common.csv
@@ -1,0 +1,3 @@
+  id,                 filename,                    label, degen, s02,   e0,                   sigma2,     deltar
+   1,        feff/feff0001.dat,                   S.Fe.1, degen_variable, s02,   e0,                   sigma2, alpha*reff
+   2,        feff/feff0002.dat,                   S.Fe.2, degen_variable, s02,   e0,                   sigma2, alpha*reff

--- a/larch_select_paths/test-data/sp_select_all_false_degen_unique.csv
+++ b/larch_select_paths/test-data/sp_select_all_false_degen_unique.csv
@@ -1,0 +1,3 @@
+  id,                 filename,                    label, degen, s02,   e0,                   sigma2,     deltar
+   1,        feff/feff0001.dat,                   S.Fe.1, degen_variable_sfe1, s02,   e0,                   sigma2, alpha*reff
+   2,        feff/feff0002.dat,                   S.Fe.2, degen_variable_sfe2, s02,   e0,                   sigma2, alpha*reff


### PR DESCRIPTION
Fix and improve clarity for handling of degeneracy:
- Explicit choice (at the defaults level) for FEFF or manual definition of degeneracy and whether this should be varied:
  - FEFF and not varied: The special variable name `degen` is used, which is recognised by the FEFFIT process and leads to the FEFF path degen values being fixed. Value is None.
  - FEFF and varied: GDS is populated with the values from the CSV summary as initial guesses. The names are unique to each path, using the prefix `degen_variable`
  - Not FEFF: behaves like a normal GDS variable, and can either by common or path specific with the prefix `degen_variable`. 
- At the path level, degeneracy will be overwritten as before but now a value is required, defaulting to 1

Closes #86